### PR TITLE
Allow release updates in GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
         bodyFile: CHANGELOG_FORMATTED.md
         draft: false
         prerelease: false
+        allowUpdates: true
         token: ${{ secrets.GITHUB_TOKEN }}
 
   build-packages:


### PR DESCRIPTION
- Added `allowUpdates: true` to the `release.yml` workflow.
- Enables updating existing GitHub releases with new artifacts.